### PR TITLE
feat: スマホ操作用の十字キーを追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,15 @@
             <button id="reset-button" style="display: none;">リセット</button>
         </div>
     </div>
+
+    <div id="dpad-container">
+        <button id="dpad-up" class="dpad-btn">▲</button>
+        <button id="dpad-left" class="dpad-btn">◀</button>
+        <div class="dpad-center"></div>
+        <button id="dpad-right" class="dpad-btn">▶</button>
+        <button id="dpad-down" class="dpad-btn">▼</button>
+    </div>
+
     <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -197,6 +197,12 @@ document.addEventListener("DOMContentLoaded", () => {
 		}
 	});
 
+	// D-pad event listeners
+	document.getElementById("dpad-up").addEventListener("click", () => move(-1, 0));
+	document.getElementById("dpad-down").addEventListener("click", () => move(1, 0));
+	document.getElementById("dpad-left").addEventListener("click", () => move(0, -1));
+	document.getElementById("dpad-right").addEventListener("click", () => move(0, 1));
+
 	resetButton.addEventListener("click", init);
 
 	init();

--- a/style.css
+++ b/style.css
@@ -145,3 +145,62 @@ body {
     background-color: #4169e1; /* 服の色 (RoyalBlue) */
     z-index: 2; /* 手前に表示 */
 }
+
+/* D-pad styling */
+#dpad-container {
+    display: grid;
+    grid-template-columns: repeat(3, 50px);
+    grid-template-rows: repeat(3, 50px);
+    gap: 5px;
+    margin: 20px auto;
+    width: 160px; /* (50px * 3) + (5px * 2) */
+    position: fixed;
+    bottom: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    opacity: 0.8;
+}
+
+.dpad-btn {
+    background-color: #888;
+    color: white;
+    border: 2px solid #555;
+    border-radius: 10px;
+    font-size: 24px;
+    cursor: pointer;
+    user-select: none; /* Prevent text selection on tap */
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.dpad-btn:active {
+    background-color: #666;
+}
+
+#dpad-up {
+    grid-column: 2;
+    grid-row: 1;
+}
+
+#dpad-left {
+    grid-column: 1;
+    grid-row: 2;
+}
+
+#dpad-right {
+    grid-column: 3;
+    grid-row: 2;
+}
+
+#dpad-down {
+    grid-column: 2;
+    grid-row: 3;
+}
+
+.dpad-center {
+    grid-column: 2;
+    grid-row: 2;
+    background-color: #555;
+    border-radius: 50%;
+}


### PR DESCRIPTION
スマートフォンやタッチデバイスでゲームをプレイできるように、画面上に十字キーを追加します。

- `index.html` に十字キーのHTML要素を追加
- `style.css` で十字キーのスタイルを定義し、操作しやすいように画面下部に配置
- `script.js` で十字キーのボタンにクリックイベントリスナーを追加し、既存の `move()` 関数を呼び出してプレイヤーを操作