### PR TITLE
feat: Add undo button and coordinate display

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,11 +11,14 @@
     <h1>倉庫番ゲーム</h1>
     <p>矢印キーでキャラクターを操作し、すべての箱(X)を青いゴール(○)に運んでください。</p>
     <div id="game-container">
+        <div id="horizontal-coords"></div>
+        <div id="vertical-coords"></div>
         <div id="game-board"></div>
         <div id="message-container">
             <p id="message"></p>
         </div>
         <button id="reset-button" style="display: none;"><span class="material-icons">refresh</span></button>
+        <button id="back-button" style="display: none;"><span class="material-icons">replay</span></button>
     </div>
 
     <div id="dpad-container">

--- a/script.js
+++ b/script.js
@@ -2,6 +2,11 @@ document.addEventListener("DOMContentLoaded", () => {
 	const gameBoard = document.getElementById("game-board");
 	const messageEl = document.getElementById("message");
 	const resetButton = document.getElementById("reset-button");
+	const backButton = document.getElementById("back-button");
+    const verticalCoords = document.getElementById("vertical-coords");
+    const horizontalCoords = document.getElementById("horizontal-coords");
+
+	let lastState = null;
 
 	// 0: 床, 1: 壁, 2: 箱, 3: ゴール, 4: プレイヤー
 	// ご指定のマップに修正
@@ -26,6 +31,8 @@ document.addEventListener("DOMContentLoaded", () => {
 		gameOver = false;
 		messageEl.textContent = "";
 		resetButton.style.display = "none";
+		backButton.style.display = "none";
+		lastState = null;
 
 		goalCount = 0;
 		for (let y = 0; y < gameMap.length; y++) {
@@ -44,8 +51,32 @@ document.addEventListener("DOMContentLoaded", () => {
 		if (initialMap[playerPos.y][playerPos.x] === 3) {
 			goalCount++;
 		}
+        setupCoords();
 		render();
 	}
+
+    function setupCoords() {
+        verticalCoords.innerHTML = "";
+        horizontalCoords.innerHTML = "";
+
+        const rows = gameMap.length;
+        const cols = gameMap[0].length;
+
+        verticalCoords.style.gridTemplateRows = `repeat(${rows}, 40px)`;
+        horizontalCoords.style.gridTemplateColumns = `repeat(${cols}, 40px)`;
+
+        const kanji = ["一", "二", "三", "四", "五", "六", "七"];
+        for (let i = 0; i < rows; i++) {
+            const coord = document.createElement("div");
+            coord.textContent = i + 1;
+            verticalCoords.appendChild(coord);
+        }
+        for (let i = 0; i < cols; i++) {
+            const coord = document.createElement("div");
+            coord.textContent = kanji[i];
+            horizontalCoords.appendChild(coord);
+        }
+    }
 
 	function render() {
 		gameBoard.innerHTML = "";
@@ -97,6 +128,12 @@ document.addEventListener("DOMContentLoaded", () => {
 	function move(dy, dx) {
 		if (gameOver) return;
 
+		// Save current state before moving
+		lastState = {
+			map: gameMap.map(row => [...row]),
+			pos: { ...playerPos }
+		};
+
 		const { y, x } = playerPos;
 		const nextY = y + dy;
 		const nextX = x + dx;
@@ -140,6 +177,7 @@ document.addEventListener("DOMContentLoaded", () => {
 		playerPos = { y: nextY, x: nextX };
 
 		resetButton.style.display = "inline-block"; // Show reset button after first move
+		backButton.style.display = "inline-block"; // Show back button after first move
 		render();
 		checkWin();
 	}
@@ -205,6 +243,16 @@ document.addEventListener("DOMContentLoaded", () => {
 	document.getElementById("dpad-right").addEventListener("click", () => move(0, 1));
 
 	resetButton.addEventListener("click", init);
+	backButton.addEventListener("click", undoMove);
+
+	function undoMove() {
+		if (lastState) {
+			gameMap = lastState.map;
+			playerPos = lastState.pos;
+			lastState = null; // Prevent multiple undos
+			render();
+		}
+	}
 
 	init();
 });

--- a/style.css
+++ b/style.css
@@ -7,14 +7,35 @@ body {
 }
 
 #game-container {
+    display: grid;
+    grid-template-columns: 40px auto; /* Coords column and game board column */
+    grid-template-rows: 40px auto; /* Coords row and game board row */
+    grid-template-areas:
+        ". h-coords"
+        "v-coords g-board";
+    margin: 20px auto;
     position: relative;
-    display: flex;
-    flex-direction: column;
+    width: fit-content; /* Adjust width to content */
+}
+
+#horizontal-coords {
+    grid-area: h-coords;
+    display: grid;
     align-items: center;
-    margin-top: 20px;
+    justify-items: center;
+    font-weight: bold;
+}
+
+#vertical-coords {
+    grid-area: v-coords;
+    display: grid;
+    align-items: center;
+    justify-items: center;
+    font-weight: bold;
 }
 
 #game-board {
+    grid-area: g-board;
     display: grid;
     border: 2px solid #333;
     background-color: #ff7f50; /* 床の色 (Coral) */
@@ -40,6 +61,22 @@ body {
     cursor: pointer;
     border: none;
     background-color: #5cb85c;
+    color: white;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+#back-button {
+    position: absolute;
+    bottom: 10px;
+    left: 10px;
+    padding: 10px;
+    font-size: 1em;
+    cursor: pointer;
+    border: none;
+    background-color: #f0ad4e;
     color: white;
     border-radius: 50%;
     display: flex;


### PR DESCRIPTION
This commit introduces two new features to the Sokoban game:

1.  **Undo Move Functionality:**
    - Adds a new 'Replay' button that allows you to undo your last move.
    - The game state (including box positions) is saved before each move.
    - The undo button restores the previous state. Only a single undo is possible.

2.  **Coordinate Grid Display:**
    - Adds row and column coordinates to the game board.
    - Rows are labeled with numbers (1-8) on the left.
    - Columns are labeled with Kanji numerals (一-七) on the top.
    - The layout is implemented using CSS Grid for proper alignment.

@gemini-cli check this PR.